### PR TITLE
Added the "en-GB" culture

### DIFF
--- a/F1InXAML/MainViewModel.cs
+++ b/F1InXAML/MainViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Windows.Input;
 using System.Windows.Markup;
 
@@ -15,6 +17,9 @@ namespace F1InXAML
 
         public MainViewModel()
         {
+            CultureInfo ci = new CultureInfo("en-GB");
+            Thread.CurrentThread.CurrentCulture = ci;
+
             CommandManager.RegisterClassCommandBinding(typeof(MainWindow), new CommandBinding(NavigationCommands.ShowRaceCommand, ShowRaceExecuted));
             CommandManager.RegisterClassCommandBinding(typeof(MainWindow), new CommandBinding(NavigationCommands.ShowSeasonCommand, ShowSeasonExecuted));
             CommandManager.RegisterClassCommandBinding(typeof(MainWindow), new CommandBinding(NavigationCommands.GoBackCommand, GoBackExecuted));


### PR DESCRIPTION
That way, people (like me) with comma as the decimal separator can run the program. Using InvariantCulture would be better but doesn't sit well with the AttributeValueOrThrow ext. method.